### PR TITLE
Update unbound.conf because defaults changed.

### DIFF
--- a/unbound.conf
+++ b/unbound.conf
@@ -16,10 +16,10 @@ server:
 	auto-trust-anchor-file: "/var/tmp/keyroll-unbound/keyroll-systems-root.key"
 	
 	# instruct the auto-trust-anchor-file probing to add anchors after ttl.
-	# add-holddown: 2592000 # 30 days
+	add-holddown: 3600 # 60 min - the key in the testbed rolls quickly - that's kinda the point!
 
 	# instruct the auto-trust-anchor-file probing to del anchors after ttl.
-	# del-holddown: 2592000 # 30 days
+	# del-holddown: 3600 # 60 min - the key in the testbed rolls quickly - that's kinda the point!
 
 	# auto-trust-anchor-file probing removes missing anchors after ttl.
 	# If the value 0 is given, missing anchors are not removed.


### PR DESCRIPTION
It _appears_ that Unbound now has default add-holddown and del-holddown.

Override them for the testbed.
